### PR TITLE
turn panic into error in WavReader::read_fmt_chunk

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -234,7 +234,7 @@ impl<R> WavReader<R> where R: io::Read {
         // could be dealing with WAVEFORMATEX or WAVEFORMATEXTENSIBLE. This is
         // not supported at this point.
         if chunk_len > 16 {
-            panic!("wave format type not implemented yet");
+            return Err(Error::FormatError("wave format type not implemented yet"));
         }
 
         let spec = WavSpec {


### PR DESCRIPTION
Encountering an fmt chunk bigger than 16 bytes caused panic, which is
unsuitable for a library.

This patch changes the panic into a FormatError, allowing clients to handle
this situation as they wish.